### PR TITLE
Fixed conditional check for when no meetings exist

### DIFF
--- a/zoom.rb
+++ b/zoom.rb
@@ -79,7 +79,7 @@ elsif match = paste.match(NUM_REGEX)
   )
 end
 
-if entries.empty?
+if entries.compact.empty?
   entries << Alfred::Item.new(
     title: "You have no zoom meetings coming up.",
     icon: icon,


### PR DESCRIPTION
I just started a new job where Zoom is the standard meeting software and as I don't have many meetings scheduled at the moment, running the workflow without any meetings was not giving any feedback because the conditional checking for `entries` emptiness was counting `nil`.