### PR TITLE
Support zoom `Personal Link`s

### DIFF
--- a/zoom.rb
+++ b/zoom.rb
@@ -2,7 +2,7 @@
 
 require_relative "alfred"
 
-ZOOM_REGEX = %r((?<url>https://([a-z0-9-]+\.)?zoom.us/./(?<meeting_id>\d+(\?pwd=\w+)?)))mi
+ZOOM_REGEX = %r((?<url>https://([a-z0-9-]+\.)?zoom.us/.{1,2}/(?<meeting_id>[a-z0-9\.]+(\?pwd=\w+)?)))mi
 HREF_REGEX = %r(<a .*href="(?<url>[^"]+)".*>(?<title>[^<]+)<\/a>)m # a href
 URL_REGEX = %r((?<url>https?://(?!([a-z0-9-]+\.)?zoom\.us)[^\b]+)\b)mi # url, but not zoom
 NUM_REGEX = %r((?<number>\d{3}-?\d{3}-?\d{3}))


### PR DESCRIPTION
* `Personal Link`s include `/my/`, rather than a single character, between the host and `meeting_id`.
* `Personal Link`s must be 5 to 40 characters.
* `Personal Link`s must start with a letter and can contain only letters (a-z), numbers (0-9) and periods (".").